### PR TITLE
fix: update Google Auth to use environment variables

### DIFF
--- a/src/components/auth/GoogleAuthButton.jsx
+++ b/src/components/auth/GoogleAuthButton.jsx
@@ -1,10 +1,12 @@
-/* needed */
 // src/components/auth/GoogleAuthButton.jsx
 import React from 'react';
 
 const GoogleAuthButton = () => {
+  // 🌍 שימוש ב-Environment Variables
+  const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3333';
+  
   const handleGoogleAuth = () => {
-    window.location.href = 'http://localhost:3333/user/google';
+    window.location.href = `${apiUrl}/user/google`;
   };
 
   return (


### PR DESCRIPTION
- Update GoogleAuthButton to use VITE_API_URL instead of hardcoded localhost
- Add CLIENT_URL environment variable for better configuration
- Update .env files for development and production environments
- Fix Google OAuth redirect URLs to work in both dev and prod