### PR TITLE
fix: update Google Auth to use environment variables

### DIFF
--- a/src/components/auth/GoogleAuthButton.jsx
+++ b/src/components/auth/GoogleAuthButton.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 const GoogleAuthButton = () => {
   // 🌍 שימוש ב-Environment Variables
-  const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3333';
+  const apiUrl = import.meta.env.VITE_API_URL || 'product-pick-server.onrender.com';
   
   const handleGoogleAuth = () => {
     window.location.href = `${apiUrl}/user/google`;


### PR DESCRIPTION
- Update GoogleAuthButton to use VITE_API_URL instead of hardcoded localhost
- Add CLIENT_URL environment variable for better configuration
- Update .env files for development and production environments
- Fix Google OAuth redirect URLs to work in both dev and prod